### PR TITLE
Support partitions: Better identification of Materialized views  to be used for a Query.

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/MaterializedViewSubstitutionVisitor.java
+++ b/core/src/main/java/org/apache/calcite/plan/MaterializedViewSubstitutionVisitor.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package plan;
+
+import org.apache.calcite.plan.SubstitutionVisitor;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+/**
+ * Substitutes part of a tree of relational expressions with another tree.
+ *
+ * <p>The call {@code new SubstitutionVisitor(target, query).go(replacement))}
+ * will return {@code query} with every occurrence of {@code target} replaced
+ * by {@code replacement}.</p>
+ *
+ * <p>The following example shows how {@code SubstitutionVisitor} can be used
+ * for materialized view recognition.</p>
+ *
+ * <ul>
+ * <li>query = SELECT a, c FROM t WHERE x = 5 AND b = 4</li>
+ * <li>target = SELECT a, b, c FROM t WHERE x = 5</li>
+ * <li>replacement = SELECT * FROM mv</li>
+ * <li>result = SELECT a, c FROM mv WHERE b = 4</li>
+ * </ul>
+ *
+ * <p>Note that {@code result} uses the materialized view table {@code mv} and a
+ * simplified condition {@code b = 4}.</p>
+ *
+ * <p>Uses a bottom-up matching algorithm. Nodes do not need to be identical.
+ * At each level, returns the residue.</p>
+ *
+ * <p>The inputs must only include the core relational operators:
+ * {@link org.apache.calcite.rel.logical.LogicalTableScan},
+ * {@link LogicalFilter},
+ * {@link LogicalProject},
+ * {@link org.apache.calcite.rel.logical.LogicalJoin},
+ * {@link LogicalUnion},
+ * {@link LogicalAggregate}.</p>
+ */
+public class MaterializedViewSubstitutionVisitor extends SubstitutionVisitor {
+
+  public MaterializedViewSubstitutionVisitor(RelNode target_, RelNode query_) {
+    super(target_, query_);
+    this.unifyRules = ImmutableList.<UnifyRule>of(ProjectToProjectUnifyRule1.INSTANCE);
+  }
+
+  public RelNode go(RelNode replacement_) {
+    this.RULE_MAP.clear();
+    return super.go(replacement_);
+  }
+
+  /**
+   * Project to Project Unify rule.
+   */
+
+  private static class ProjectToProjectUnifyRule1 extends AbstractUnifyRule {
+    public static final ProjectToProjectUnifyRule1 INSTANCE =
+            new ProjectToProjectUnifyRule1();
+
+    private ProjectToProjectUnifyRule1() {
+      super(operand(MutableProject.class, query(0)),
+              operand(MutableProject.class, target(0)), 1);
+    }
+
+    @Override
+    protected UnifyResult apply(UnifyRuleCall call) {
+      final MutableProject target = (MutableProject) call.target;
+      final MutableProject query = (MutableProject) call.query;
+      final RexShuttle shuttle = getRexShuttle(target);
+      final List<RexNode> newProjects;
+      try {
+        newProjects = shuttle.apply(query.getProjects());
+      } catch (MatchFailed e) {
+        return null;
+      }
+      final MutableProject newProject =
+              MutableProject.of(
+                      query.getRowType(), target, newProjects);
+      final MutableRel newProject2 = MutableRels.strip(newProject);
+      return call.result(newProject2);
+    }
+
+    @Override
+    protected UnifyRuleCall match(SubstitutionVisitor visitor, MutableRel query,
+                        MutableRel target) {
+      if (queryOperand.matches(visitor, query)) {
+        if (targetOperand.matches(visitor, target)) {
+          return null;
+        } else if (targetOperand.isWeaker(visitor, target)) {
+
+          final MutableProject queryProject = (MutableProject) query;
+          final MutableProject queryTarget = (MutableProject) target;
+          if (queryProject.getInput() instanceof MutableFilter) {
+
+            final MutableFilter innerFilter = (MutableFilter) (queryProject.getInput());
+            final RexNode newCondition = innerFilter.getCondition();
+            final MutableFilter newFilter = MutableFilter.of(target,
+                    newCondition);
+
+            final MutableProject newTarget =
+                    MutableProject.of(queryProject.getRowType(), newFilter,
+                            queryProject.getProjects());
+
+            return visitor.new UnifyRuleCall(this, query, newTarget,
+                    copy(visitor.getSlots(), slotCount));
+          }
+        }
+      }
+      return null;
+    }
+  }
+}
+
+// End SubstitutionVisitor.java

--- a/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
+++ b/core/src/main/java/org/apache/calcite/plan/RexImplicationChecker.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package plan;
+
+import org.apache.calcite.DataContext;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.VisitorDataContext;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexExecutable;
+import org.apache.calcite.rex.RexExecutorImpl;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlCastFunction;
+import org.apache.calcite.util.Pair;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+
+/** Checks if Condition X logically implies Condition Y
+ *
+ * <p>(x > 10) implies (x > 5)</p>
+ *
+ * <p>(y = 10) implies (y < 30 AND x > 30)</p>
+ */
+public class RexImplicationChecker {
+  final RexBuilder builder;
+  final RexExecutorImpl rexImpl;
+  final RelDataType rowType;
+
+  public RexImplicationChecker(RexBuilder builder,
+                                RexExecutorImpl rexImpl,
+                                RelDataType rowType) {
+    this.builder = builder;
+    this.rexImpl = rexImpl;
+    this.rowType = rowType;
+  }
+
+  /**
+   * Checks if condition first implies (=>) condition second
+   * This reduces to SAT problem which is NP-Complete
+   * When func says first => second then it is definitely true
+   * It cannot prove if first doesnot imply second.
+   * @param first
+   * @param second
+   * @return true if it can prove first => second, otherwise false i.e.,
+   * it doesn't know if implication holds .
+   */
+  public boolean implies(RexNode first, RexNode second) {
+
+    // Validation
+    if (!validate(first, second)) {
+      return false;
+    }
+
+    RexCall firstCond = (RexCall) first;
+    RexCall secondCond = (RexCall) second;
+
+    // Get DNF
+    RexNode firstDnf = RexUtil.toDnf(builder, first);
+    RexNode secondDnf = RexUtil.toDnf(builder, second);
+
+    // Check Trivial Cases
+    if (firstDnf.isAlwaysFalse()
+            || secondDnf.isAlwaysTrue()) {
+      return true;
+    }
+
+    /** Decompose DNF into List of Conjunctions
+     *
+     * (x > 10 AND y > 30) OR (z > 90) will be converted to
+     * list of 2 conditions:
+     * 1. (x > 10 AND y > 30)
+     * 2. (z > 90)
+     *
+     */
+    List<RexNode> firstDnfs = RelOptUtil.disjunctions(firstDnf);
+    List<RexNode> secondDnfs = RelOptUtil.disjunctions(secondDnf);
+
+    for (RexNode f : firstDnfs) {
+      if (!f.isAlwaysFalse()) {
+        //Check if f implies atleast
+        // one of the conjunctions in list secondDnfs
+        boolean implyOneConjuntion = false;
+        for (RexNode s : secondDnfs) {
+          if (s.isAlwaysFalse()) { // f cannot imply s
+            continue;
+          }
+
+          if (impliesConjunction(f, s)) {
+            // Satisfies one of the condition, so lets
+            // move to next conjunction in firstDnfs
+            implyOneConjuntion = true;
+            break;
+          }
+        } //end of inner loop
+
+        // If f couldnot imply even one conjunction in
+        // secondDnfs, then final implication may be false
+        if (!implyOneConjuntion) {
+          return false;
+        }
+      }
+    } //end of outer loop
+
+    return true;
+  }
+
+  /** Checks if conjunction first => Conjunction second**/
+  private boolean impliesConjunction(RexNode first, RexNode second) {
+
+    InputUsageFinder firstUsgFinder = new InputUsageFinder();
+    InputUsageFinder secondUsgFinder = new InputUsageFinder();
+
+    RexUtil.apply(firstUsgFinder, new ArrayList<RexNode>(), first);
+    RexUtil.apply(secondUsgFinder, new ArrayList<RexNode>(), second);
+
+    // Check Support
+
+    if (!checkSupport(firstUsgFinder, secondUsgFinder)) {
+      return false;
+    }
+
+    List<Pair<RexInputRef, RexNode>> usgList = new ArrayList<>();
+    for (Map.Entry<RexInputRef, InputRefUsage<SqlOperator,
+            RexNode>> entry: firstUsgFinder.usageMap.entrySet()) {
+      final List<Pair<SqlOperator, RexNode>> list = entry.getValue().getUsageList();
+      usgList.add(Pair.of(entry.getKey(), list.get(0).getValue()));
+    }
+
+    final DataContext dataValues = VisitorDataContext.getDataContext(rowType, usgList);
+
+    if (dataValues == null) {
+      return false;
+    }
+
+    ImmutableList<RexNode> constExps = ImmutableList.of(second);
+    final RexExecutable exec = rexImpl.getExecutable(builder,
+            constExps, rowType);
+
+    exec.setDataContext(dataValues);
+    Object[] result = exec.execute();
+
+    return result != null && result.length == 1 && result[0] instanceof Boolean
+            && (Boolean) result[0];
+  }
+
+  private boolean checkSupport(InputUsageFinder firstUsgFinder, InputUsageFinder secondUsgFinder) {
+    Map<RexInputRef, InputRefUsage<SqlOperator,
+            RexNode>> firstUsgMap = firstUsgFinder.usageMap;
+    Map<RexInputRef, InputRefUsage<SqlOperator,
+            RexNode>> secondUsgMap = secondUsgFinder.usageMap;
+
+    for (Map.Entry<RexInputRef, InputRefUsage<SqlOperator,
+            RexNode>> entry: firstUsgMap.entrySet()) {
+      if (entry.getValue().usageCount > 1) {
+        return false;
+      }
+    }
+
+    for (Map.Entry<RexInputRef, InputRefUsage<SqlOperator,
+            RexNode>> entry: secondUsgMap.entrySet()) {
+      final InputRefUsage<SqlOperator, RexNode> secondUsage = entry.getValue();
+      if (secondUsage.usageCount > 1
+              || secondUsage.usageList.size() != 1) {
+        return false;
+      }
+
+      final InputRefUsage<SqlOperator, RexNode> firstUsage = firstUsgMap.get(entry.getKey());
+      if (firstUsage == null
+              || firstUsage.usageList.size() != 1) {
+        return false;
+      }
+
+      final Pair<SqlOperator, RexNode> fUse = firstUsage.getUsageList().get(0);
+      final Pair<SqlOperator, RexNode> sUse = secondUsage.getUsageList().get(0);
+
+      final SqlKind fkind = fUse.getKey().getKind();
+
+      switch (sUse.getKey().getKind()) {
+      case GREATER_THAN:
+      case GREATER_THAN_OR_EQUAL:
+        if (!(fkind == SqlKind.GREATER_THAN)
+                && !(fkind == SqlKind.GREATER_THAN_OR_EQUAL)) {
+          return false;
+        }
+        break;
+      case LESS_THAN:
+      case LESS_THAN_OR_EQUAL:
+        if (!(fkind == SqlKind.LESS_THAN)
+                && !(fkind == SqlKind.LESS_THAN_OR_EQUAL)) {
+          return false;
+        }
+        break;
+      default:
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean validate(RexNode first, RexNode second) {
+    if (first == null || second == null) {
+      return false;
+    }
+    if (!(first instanceof RexCall)
+            || !(second instanceof RexCall)) {
+      return false;
+    }
+    return true;
+  }
+
+
+  /**
+   * Visitor which builds a Usage Map of inputs used by an expression.
+   */
+  private static class InputUsageFinder extends RexVisitorImpl<Void> {
+    public final Map<RexInputRef, InputRefUsage<SqlOperator,
+            RexNode>> usageMap = new HashMap<>();
+
+    public InputUsageFinder() {
+      super(true);
+    }
+
+    public Void visitInputRef(RexInputRef inputRef) {
+      InputRefUsage<SqlOperator,
+              RexNode> inputRefUse = getUsageMap(inputRef);
+      inputRefUse.incrUsage();
+      return null;
+    }
+
+    @Override public Void visitCall(RexCall call) {
+      switch (call.getOperator().getKind()) {
+      case GREATER_THAN:
+      case GREATER_THAN_OR_EQUAL:
+      case LESS_THAN:
+      case LESS_THAN_OR_EQUAL:
+      case EQUALS:
+        updateUsage(call);
+        break;
+      default:
+      }
+      return super.visitCall(call);
+    }
+
+    private void updateUsage(RexCall call) {
+      final List<RexNode> operands = call.getOperands();
+      RexNode first = removeCast(operands.get(0));
+      RexNode second = removeCast(operands.get(1));
+
+      if (first.isA(SqlKind.INPUT_REF)
+              && second.isA(SqlKind.LITERAL)) {
+        updateUsage(call.getOperator(), (RexInputRef) first, second);
+      }
+
+      if (first.isA(SqlKind.LITERAL)
+              && second.isA(SqlKind.INPUT_REF)) {
+        updateUsage(call.getOperator(), (RexInputRef) second, first);
+      }
+    }
+
+    private static RexNode removeCast(RexNode inputRef) {
+      if (inputRef instanceof RexCall) {
+        final RexCall castedRef = (RexCall) inputRef;
+        final SqlOperator operator = castedRef.getOperator();
+        if (operator instanceof SqlCastFunction) {
+          inputRef = castedRef.getOperands().get(0);
+        }
+      }
+      return inputRef;
+    }
+
+    private void updateUsage(SqlOperator op, RexInputRef inputRef, RexNode literal) {
+      InputRefUsage<SqlOperator,
+              RexNode> inputRefUse = getUsageMap(inputRef);
+      Pair<SqlOperator, RexNode> use = Pair.of(op, literal);
+      inputRefUse.getUsageList().add(use);
+    }
+
+    private InputRefUsage<SqlOperator, RexNode> getUsageMap(RexInputRef rex) {
+      InputRefUsage<SqlOperator, RexNode> inputRefUse = usageMap.get(rex);
+      if (inputRefUse == null) {
+        inputRefUse = new InputRefUsage<>();
+        usageMap.put(rex, inputRefUse);
+      }
+
+      return inputRefUse;
+    }
+  }
+
+  /**
+   * DataStructure to store usage of InputRefs in expression
+   * @param <T1>
+   * @param <T2>
+   */
+
+  private static class InputRefUsage<T1, T2> {
+    final List<Pair<T1, T2>> usageList =
+            new ArrayList<Pair<T1, T2>>();
+    int usageCount = 0;
+
+    public InputRefUsage() {}
+
+    public int getUsageCount() {
+      return usageCount;
+    }
+
+    public void incrUsage() {
+      usageCount++;
+    }
+
+
+    public List<Pair<T1, T2>> getUsageList() {
+      return usageList;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
+++ b/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.plan;
+
+import org.apache.calcite.DataContext;
+import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.linq4j.QueryProvider;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactoryImpl.JavaType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlCastFunction;
+import org.apache.calcite.util.NlsString;
+import org.apache.calcite.util.Pair;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.util.List;
+
+/**
+ * DataContext for evaluating an RexExpression
+ */
+public class VisitorDataContext implements DataContext {
+  private final Object[] values;
+
+  public VisitorDataContext(Object[] values) {
+    this.values = values;
+  }
+
+  public SchemaPlus getRootSchema() {
+    throw new RuntimeException("Unsupported");
+  }
+
+  public JavaTypeFactory getTypeFactory() {
+    throw new RuntimeException("Unsupported");
+  }
+
+  public QueryProvider getQueryProvider() {
+    throw new RuntimeException("Unsupported");
+  }
+
+  public Object get(String name) {
+    if (name.equals("inputRecord")) {
+      return values;
+    } else {
+      return null;
+    }
+  }
+  public static DataContext getDataContext(RelNode targetRel, LogicalFilter queryRel) {
+    return getDataContext(targetRel.getRowType(), queryRel.getCondition());
+  }
+
+  public static DataContext getDataContext(RelDataType rowType, RexNode rex) {
+    int size = rowType.getFieldList().size();
+    Object[] values = new Object[size];
+    List<RexNode> operands = ((RexCall) rex).getOperands();
+    final RexNode firstOperand = operands.get(0);
+    final RexNode secondOperand = operands.get(1);
+    final Pair<Integer, ? extends Object> value = getValue(firstOperand, secondOperand);
+    if (value != null) {
+      int index = value.getKey();
+      values[index] = value.getValue();
+      return new VisitorDataContext(values);
+    } else {
+      return null;
+    }
+  }
+
+  public static DataContext getDataContext(RelDataType rowType, List<Pair<RexInputRef,
+          RexNode>> usgList) {
+    int size = rowType.getFieldList().size();
+    Object[] values = new Object[size];
+    for (Pair<RexInputRef, RexNode> elem: usgList) {
+      Pair<Integer, ? extends Object> value = getValue(elem.getKey(), elem.getValue());
+      if (value == null) {
+        return null;
+      }
+      int index = value.getKey();
+      values[index] = value.getValue();
+    }
+    return new VisitorDataContext(values);
+  }
+
+  public static Pair<Integer, ? extends Object> getValue(RexNode inputRef, RexNode literal) {
+    inputRef = removeCast(inputRef);
+    literal = removeCast(literal);
+
+    if (inputRef instanceof RexInputRef
+            && literal instanceof RexLiteral)  {
+      Integer index = ((RexInputRef) inputRef).getIndex();
+      Object value = ((RexLiteral) literal).getValue();
+      final Class javaClass = ((JavaType) (inputRef.getType())).getJavaClass();
+      if (javaClass == Integer.class
+              && value instanceof BigDecimal) {
+        final Integer intValue = new Integer(((BigDecimal) value).intValue());
+        return  Pair.of(index, intValue);
+      }
+      if (javaClass == Date.class
+              && value instanceof NlsString) {
+        value = ((RexLiteral) literal).getValue2();
+        final Date dateValue = Date.valueOf((String) value);
+        return Pair.of(index, dateValue);
+      }
+
+      if (javaClass == Double.class
+              && value instanceof BigDecimal) {
+        return Pair.of(index,
+                new Double(((BigDecimal) value).doubleValue()));
+      }
+      return Pair.of(index, value);
+    }
+
+    return null;
+  }
+
+  private static RexNode removeCast(RexNode inputRef) {
+    if (inputRef instanceof RexCall) {
+      final RexCall castedRef = (RexCall) inputRef;
+      final SqlOperator operator = castedRef.getOperator();
+      if (operator instanceof SqlCastFunction) {
+        inputRef = castedRef.getOperands().get(0);
+      }
+    }
+    return inputRef;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -1023,6 +1023,38 @@ public class RexUtil {
     return new CnfHelper(rexBuilder).toCnf(rex);
   }
 
+  /** Converts an expression to disjunctive normal form (DNF).
+   *
+   * <p>DNF: It is a form of logical formula which is disjunction of conjunctive clauses</p>
+   *
+   * <p>All logicl formulas can be converted into DNF.</p>
+   *
+   * <p>The following expression is in DNF:
+   *
+   * <blockquote>(a AND b) OR (c AND d)</blockquote>
+   *
+   * <p>The following expression is not in CNF:
+   *
+   * <blockquote>(a OR b) AND c</blockquote>
+   *
+   * but can be converted to DNF:
+   *
+   * <blockquote>(a AND c) OR (b AND c)</blockquote>
+   *
+   * <p>The following expression is not in CNF:
+   *
+   * <blockquote>NOT (a OR NOT b)</blockquote>
+   *
+   * but can be converted to DNF by applying de Morgan's theorem:
+   *
+   * <blockquote>NOT a AND b</blockquote>
+   *
+   * <p>Expressions not involving AND, OR or NOT at the top level are in DNF.
+   */
+  public static RexNode toDnf(RexBuilder rexBuilder, RexNode rex) {
+    return new DnfHelper(rexBuilder).toDnf(rex);
+  }
+
   /**
    * Returns whether an operator is associative. AND is associative,
    * which means that "(x AND y) and z" is equivalent to "x AND (y AND z)".
@@ -1452,6 +1484,79 @@ public class RexUtil {
       return composeDisjunction(rexBuilder, nodes, false);
     }
   }
+
+  /** Helps {@link org.apache.calcite.rex.RexUtil#toDnf}. */
+  private static class DnfHelper {
+    final RexBuilder rexBuilder;
+
+    private DnfHelper(RexBuilder rexBuilder) {
+      this.rexBuilder = rexBuilder;
+    }
+
+    public RexNode toDnf(RexNode rex) {
+      final List<RexNode> operands;
+      switch (rex.getKind()) {
+      case AND:
+        operands = flattenAnd(((RexCall) rex).getOperands());
+        final RexNode head = operands.get(0);
+        final RexNode headDnf = toDnf(head);
+        final List<RexNode> headDnfs = RelOptUtil.disjunctions(headDnf);
+        final RexNode tail = and(Util.skip(operands));
+        final RexNode tailDnf = toDnf(tail);
+        final List<RexNode> tailDnfs = RelOptUtil.disjunctions(tailDnf);
+        final List<RexNode> list = Lists.newArrayList();
+        for (RexNode h : headDnfs) {
+          for (RexNode t : tailDnfs) {
+            list.add(and(ImmutableList.of(h, t)));
+          }
+        }
+        return or(list);
+      case OR:
+        operands = flattenOr(((RexCall) rex).getOperands());
+        return or(toDnfs(operands));
+      case NOT:
+        final RexNode arg = ((RexCall) rex).getOperands().get(0);
+        switch (arg.getKind()) {
+        case NOT:
+          return toDnf(((RexCall) arg).getOperands().get(0));
+        case OR:
+          operands = ((RexCall) arg).getOperands();
+          return toDnf(and(Lists.transform(flattenOr(operands), ADD_NOT)));
+        case AND:
+          operands = ((RexCall) arg).getOperands();
+          return toDnf(or(Lists.transform(flattenAnd(operands), ADD_NOT)));
+        default:
+          return rex;
+        }
+      default:
+        return rex;
+      }
+    }
+
+    private List<RexNode> toDnfs(List<RexNode> nodes) {
+      final List<RexNode> list = Lists.newArrayList();
+      for (RexNode node : nodes) {
+        RexNode dnf = toDnf(node);
+        switch (dnf.getKind()) {
+        case OR:
+          list.addAll(((RexCall) dnf).getOperands());
+          break;
+        default:
+          list.add(dnf);
+        }
+      }
+      return list;
+    }
+
+    private RexNode and(Iterable<? extends RexNode> nodes) {
+      return composeConjunction(rexBuilder, nodes, false);
+    }
+
+    private RexNode or(Iterable<? extends RexNode> nodes) {
+      return composeDisjunction(rexBuilder, nodes, false);
+    }
+  }
+
 
   /** Shuttle that adds {@code offset} to each {@link RexInputRef} in an
    * expression. */


### PR DESCRIPTION
Better identification of Materialized views that can be used for a Query.

Currently If MV is defined by select \* from foo where X and the Query is select \* from foo where Y then we caanot replace the query to run on MV (unless X and Y are identical)  even if Y => X. This fix tries to identify such cases and use MV instead.
