### PR TITLE
fix:dev:NEZ-11 Fixing wrong assignment of star table to MaterializedView

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelOptMaterialization.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelOptMaterialization.java
@@ -191,7 +191,8 @@ public class RelOptMaterialization {
           }
         });
     if (rel2 == rel) {
-      return rel;
+      // No rewrite happened.
+      return null;
     }
     final Program program = Programs.hep(
         ImmutableList.of(ProjectFilterTransposeRule.INSTANCE,

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -393,8 +393,11 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     // First, if the materialization is in terms of a star table, rewrite
     // the query in terms of the star table.
     if (materialization.starTable != null) {
-      root = RelOptMaterialization.tryUseStar(
-          root, materialization.starRelOptTable);
+      RelNode newRoot = RelOptMaterialization.tryUseStar(
+              root, materialization.starRelOptTable);
+      if (newRoot != null) {
+        root = newRoot;
+      }
     }
 
     // Push filters to the bottom, and combine projects on top.


### PR DESCRIPTION
CalciteMaterializer tries to rewrite query relnode with the star table in schema (the first one that fits). Utility function used is RelOptMaterialization::tryUseStar. Utility function should return null when it cannot rewrite relnode using star.

RelOptMaterialization::tryUseStar is used in 3 places. Couple of them expect null to be returned when star table cannot be used. One of them i.e., VolcannoPlanner::substitute is not expecting it, so rewriting it.

Testing:
All Nezha Tests are clean.
