### PR TITLE
NEZ 76 Parameterize Distribution end points 

### DIFF
--- a/avatica-server/pom.xml
+++ b/avatica-server/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.5.0-qds-r4</version>
+    <version>1.5.0-qds-r5-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-avatica-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.0-qds-r4</version>
+  <version>1.5.0-qds-r5-SNAPSHOT</version>
   <name>Calcite Avatica Server</name>
   <description>JDBC server.</description>
 

--- a/avatica/pom.xml
+++ b/avatica/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.5.0-qds-r4</version>
+    <version>1.5.0-qds-r5-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-avatica</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.0-qds-r4</version>
+  <version>1.5.0-qds-r5-SNAPSHOT</version>
   <name>Calcite Avatica</name>
   <description>JDBC driver framework.</description>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.5.0-qds-r4</version>
+    <version>1.5.0-qds-r5-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-core</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.0-qds-r4</version>
+  <version>1.5.0-qds-r5-SNAPSHOT</version>
   <name>Calcite Core</name>
   <description>Core Calcite APIs and engine.</description>
 

--- a/example/csv/pom.xml
+++ b/example/csv/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>1.5.0-qds-r4</version>
+    <version>1.5.0-qds-r5-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-example-csv</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.0-qds-r4</version>
+  <version>1.5.0-qds-r5-SNAPSHOT</version>
   <name>Calcite Example CSV</name>
   <description>An example Calcite provider that reads CSV files</description>
 

--- a/example/function/pom.xml
+++ b/example/function/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>1.5.0-qds-r4</version>
+    <version>1.5.0-qds-r5-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-example-function</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.0-qds-r4</version>
+  <version>1.5.0-qds-r5-SNAPSHOT</version>
   <name>Calcite Example Function</name>
   <description>Examples of user-defined Calcite functions</description>
 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -20,13 +20,13 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.5.0-qds-r4</version>
+    <version>1.5.0-qds-r5-SNAPSHOT</version>
   </parent>
 
   <!-- The basics. -->
   <artifactId>calcite-example</artifactId>
   <packaging>pom</packaging>
-  <version>1.5.0-qds-r4</version>
+  <version>1.5.0-qds-r5-SNAPSHOT</version>
   <name>Calcite Examples</name>
   <description>Calcite examples</description>
 

--- a/linq4j/pom.xml
+++ b/linq4j/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.5.0-qds-r4</version>
+    <version>1.5.0-qds-r5-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-linq4j</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.0-qds-r4</version>
+  <version>1.5.0-qds-r5-SNAPSHOT</version>
   <name>Calcite Linq4j</name>
   <description>Calcite APIs for LINQ (Language-Integrated Query) in Java</description>
 

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.5.0-qds-r4</version>
+    <version>1.5.0-qds-r5-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-mongodb</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.0-qds-r4</version>
+  <version>1.5.0-qds-r5-SNAPSHOT</version>
   <name>Calcite MongoDB</name>
   <description>MongoDB adapter for Calcite</description>
 

--- a/piglet/pom.xml
+++ b/piglet/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.5.0-qds-r4</version>
+    <version>1.5.0-qds-r5-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-piglet</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.0-qds-r4</version>
+  <version>1.5.0-qds-r5-SNAPSHOT</version>
   <name>Calcite Piglet</name>
   <description>Pig-like language built on top of Calcite algebra</description>
 

--- a/plus/pom.xml
+++ b/plus/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.5.0-qds-r4</version>
+    <version>1.5.0-qds-r5-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-plus</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.0-qds-r4</version>
+  <version>1.5.0-qds-r5-SNAPSHOT</version>
   <name>Calcite Plus</name>
   <description>Miscellaneous extras for Calcite</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
   <groupId>org.apache.calcite</groupId>
   <artifactId>calcite</artifactId>
   <packaging>pom</packaging>
-  <version>1.5.0-qds-r4</version>
+  <version>1.5.0-qds-r5-SNAPSHOT</version>
 
   <!-- More project information. -->
   <name>Calcite</name>
@@ -89,34 +89,34 @@ limitations under the License.
       <dependency>
         <groupId>org.apache.calcite</groupId>
         <artifactId>calcite-avatica</artifactId>
-        <version>1.5.0-qds-r4</version>
+        <version>1.5.0-qds-r5-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.calcite</groupId>
         <artifactId>calcite-avatica</artifactId>
-        <version>1.5.0-qds-r4</version>
+        <version>1.5.0-qds-r5-SNAPSHOT</version>
         <type>test-jar</type>
       </dependency>
       <dependency>
         <groupId>org.apache.calcite</groupId>
         <artifactId>calcite-avatica-server</artifactId>
-        <version>1.5.0-qds-r4</version>
+        <version>1.5.0-qds-r5-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.calcite</groupId>
         <artifactId>calcite-core</artifactId>
-        <version>1.5.0-qds-r4</version>
+        <version>1.5.0-qds-r5-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.calcite</groupId>
         <artifactId>calcite-core</artifactId>
         <type>test-jar</type>
-        <version>1.5.0-qds-r4</version>
+        <version>1.5.0-qds-r5-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.calcite</groupId>
         <artifactId>calcite-linq4j</artifactId>
-        <version>1.5.0-qds-r4</version>
+        <version>1.5.0-qds-r5-SNAPSHOT</version>
       </dependency>
 
       <!-- Now third-party dependencies, sorted by groupId and artifactId. -->

--- a/pom.xml
+++ b/pom.xml
@@ -559,6 +559,13 @@ limitations under the License.
         </plugin>
       </plugins>
     </pluginManagement>
+    <extensions>
+      <extension>
+        <groupId>org.springframework.build</groupId>
+        <artifactId>aws-maven</artifactId>
+        <version>5.0.0.RELEASE</version>
+      </extension>
+    </extensions>
   </build>
 
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -619,14 +619,14 @@ limitations under the License.
 
   <distributionManagement>
     <repository>
-      <id>qubole-releases</id>
-      <name>karma.qubole.net-releases</name>
-      <url>http://karma.qubole.net:4000/artifactory/libs-release-local</url>
+      <id>${distMgmtStagingId}</id>
+      <name>${distMgmtStagingName}</name>
+      <url>${distMgmtStagingUrl}</url>
     </repository>
     <snapshotRepository>
-      <id>qubole-snapshots</id>
-      <name>karma.qubole.net-snapshots</name>
-      <url>http://karma.qubole.net:4000/artifactory/libs-snapshot-local</url>
+      <id>${distMgmtSnapshotsId}</id>
+      <name>${distMgmtSnapshotsName}</name>
+      <url>${distMgmtSnapshotsUrl}</url>
     </snapshotRepository>
   </distributionManagement>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.5.0-qds-r4</version>
+    <version>1.5.0-qds-r5-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-spark</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.0-qds-r4</version>
+  <version>1.5.0-qds-r5-SNAPSHOT</version>
   <name>Calcite Spark</name>
 
   <properties>

--- a/splunk/pom.xml
+++ b/splunk/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.5.0-qds-r4</version>
+    <version>1.5.0-qds-r5-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-splunk</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.0-qds-r4</version>
+  <version>1.5.0-qds-r5-SNAPSHOT</version>
   <name>Calcite Splunk</name>
   <description>Splunk adapter for Calcite; also a JDBC driver for Splunk</description>
 

--- a/ubenchmark/pom.xml
+++ b/ubenchmark/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.5.0-qds-r4</version>
+    <version>1.5.0-qds-r5-SNAPSHOT</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
This change required to be able to deploy Calcite to Qubole's Maven repository hosted in a public S3 bucket. 
