### PR TITLE
new:usr:#63 Add support for hive operators and constant folding  to RexImplicationChecker

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
+++ b/core/src/main/java/org/apache/calcite/plan/VisitorDataContext.java
@@ -196,6 +196,7 @@ public class VisitorDataContext implements DataContext {
       final SqlOperator operator = castedRef.getOperator();
       if (operator instanceof SqlCastFunction) {
         inputRef = castedRef.getOperands().get(0);
+        return removeCast(inputRef);
       }
     }
     return inputRef;


### PR DESCRIPTION
This change adds support for hive operators added for issue #62 in
RexImplication checker. It also enables constant folding whenever it is
required to check if one condition implies another.
